### PR TITLE
remove static height from main container

### DIFF
--- a/style/style.css
+++ b/style/style.css
@@ -11,9 +11,9 @@ body{
     flex-wrap: wrap;
     justify-content: flex-start;
     background-color: purple;
+    padding-bottom: 0.5rem;
 }
-.display{
-    
+.display{ 
     margin: 10px 0px ;
     border: solid black 3px;
     background-color: lavender;
@@ -50,6 +50,7 @@ body{
     width: 325px;
 }
 .decimal-buttons>button{
+    max-width: 105px;
     padding: 20px 47px;
     margin: 1px;
 }
@@ -61,7 +62,7 @@ body{
 } */
 #dot{
     flex-grow: 1;
-    max-width: 211px;
+    max-width: 212px;
 }
 #equal{
     background-color: gold;
@@ -80,6 +81,7 @@ body{
     display: flex;
     flex-direction: column;
     margin-left: 7px;
+    margin-top: 1px;
     gap: 2px;
 }
 .side-buttons>button{

--- a/style/style.css
+++ b/style/style.css
@@ -6,7 +6,6 @@ body{
 .container{
     display: flex;
     width: 400px;
-    height: 470px;
     flex-direction: column;
     align-items: center;
     flex-wrap: wrap;


### PR DESCRIPTION
The static height on your main container is causing your button elements to overflow the container and show up to the right of the calculator body. I do not think this is intended. The container will grow with the size of its contents.


  - Before: ![before](https://user-images.githubusercontent.com/62824345/159136378-51d6b483-4418-4b73-9eb3-8afd0e70ef20.png)

  - After: ![after](https://user-images.githubusercontent.com/62824345/159136384-5cf6f4c0-3e89-40af-99fe-e7d8988683c2.png)
